### PR TITLE
add translate="no attribute to ide-wrapper

### DIFF
--- a/layouts/partials/ideHTML.html
+++ b/layouts/partials/ideHTML.html
@@ -1,6 +1,6 @@
 {{/* */}}
 
-<div id="ide-wrapper" class="panel animate disabled hide">
+<div id="ide-wrapper" class="panel animate disabled hide" translate="no">
   <nav id="ide-controls-top" class="control-bar fuzzy-background">
     <input
       type="checkbox"


### PR DESCRIPTION
add attributes to prevent translate code in ide when use google translate

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate